### PR TITLE
A CESK machine-style evaluator for LambdaS5

### DIFF
--- a/src/ljs/ljs_cesk.ml
+++ b/src/ljs/ljs_cesk.ml
@@ -1,0 +1,544 @@
+module C = Ljs_clos
+module D = Ljs_delta
+module L = Ljs_eval
+module GC = Ljs_gc
+module K = Ljs_kont
+module PV = Ljs_pretty_value
+module S = Ljs_syntax
+module V = Ljs_values
+module P = Prelude
+module LocSet = Store.LocSet
+module LocMap = Store.LocMap
+
+(* A CESK-style evaluator for LambdaS5 *)
+(* Written by Nicholas Labich and Adam Alix with help from David Van Horn. *)
+
+(* borrowed from ljs_eval *)
+
+let arity_mismatch_err p xs args =
+  L.interp_error p ("Arity mismatch, supplied " ^
+                    string_of_int (List.length args) ^
+                    " arguments and expected " ^
+                    string_of_int (List.length xs) ^
+                    ". Arg names were: " ^
+                    (List.fold_right (^) (P.map (fun s -> " " ^ s ^ " ") xs) "") ^
+                    ". Values were: " ^
+                    (List.fold_right (^) (P.map (fun v -> " " ^ V.pretty_value v ^ " ") args) ""))
+
+(* modified from ljs_eval to add the arguments to the environment and store,
+   then a triple of the body of the function, the updated env, and the
+   updated store. *)
+let rec apply p store func args = match func with
+  | V.Closure (env, xs, body) ->
+    let alloc_arg argval argname (store, env) =
+      let (new_loc, store) = V.add_var store argval in
+      let env' = P.IdMap.add argname new_loc env in
+      (store, env') in
+    if (List.length args) != (List.length xs) then
+      arity_mismatch_err p xs args
+    else
+      let (store, env) = (List.fold_right2 alloc_arg args xs (store, env)) in
+      (body, env, store)
+  | V.ObjLoc loc -> begin match V.get_obj store loc with
+    | ({ V.code = Some f }, _) -> apply p store f args
+    | _ -> failwith "Applied an object without a code attribute"
+  end
+  | _ -> failwith (L.interp_error p
+                     ("Applied non-function, was actually " ^
+                         V.pretty_value func))
+
+(* end borrowed ljs_eval helpers *)
+
+(* gc params *)
+let store_gc_size = 1500
+let gc_instr_count = 30000
+
+let count ((obj_s, _), (val_s, _)) =
+  let folder = (fun _ _ n -> n+1) in
+  (LocMap.fold folder obj_s 0, LocMap.fold folder val_s 0)
+
+(* misc *)
+
+let add_opt clos xs f = match f clos with
+  | Some x -> x::xs
+  | None -> xs
+
+(* eval_cesk : (string -> Ljs_syntax.exp)
+ *             clos
+ *             (objectv Store.t * value Store.t)
+ *             kont
+ *             int ->
+ *             (value * store)                   
+ * Portions of these cases are in the vein of or replications of code in
+ * ljs_eval, especially pertaining to attrs and fields. Both credit and
+ * thanks go to the original author(s). *)
+let rec eval_cesk desugar clo store kont i =
+  (* very naive gc, much room for improvement here *)
+  let store =
+    if i mod gc_instr_count = 0 then
+      match count store with
+      | obj_count, val_count ->
+        if obj_count > store_gc_size or val_count > store_gc_size then
+          Ljs_gc.collect_garbage store (LocSet.union (C.locs_of_clos clo) (K.locs_of_kont kont))
+        else store
+    else store in
+  begin
+    let eval clo store kont = eval_cesk desugar clo store kont (i+1) in
+    match clo, kont with
+    | C.ValClos (valu, env), K.Mt ->
+      (valu, store)
+    (* value cases *)
+    | C.ExpClos (S.Undefined _, env), _ ->
+      eval (C.ValClos (V.Undefined, env)) store kont
+    | C.ExpClos (S.Null _, env), _ ->
+      eval (C.ValClos (V.Null, env)) store kont
+    | C.ExpClos (S.String (_, s), env), _ ->
+      eval (C.ValClos (V.String s, env)) store kont
+    | C.ExpClos (S.Num (_, n), env), _ ->
+      eval (C.ValClos (V.Num n, env)) store kont
+    | C.ExpClos (S.True _, env), _ ->
+      eval (C.ValClos (V.True, env)) store kont
+    | C.ExpClos (S.False _, env), _ ->
+      eval (C.ValClos (V.False, env)) store kont
+    | C.ExpClos (S.Id (p, name), env), _ ->
+      (match try V.get_maybe_var store (P.IdMap.find name env) with Not_found -> None with
+      | Some valu -> eval (C.ValClos (valu, env)) store kont
+      | None      -> failwith ("[interp] Unbound identifier: " ^ name ^ " in identifier lookup at " ^
+                                  (P.Pos.string_of_pos p)))
+    | C.ExpClos (S.Lambda (_, xs, body), env), k ->
+      let free = S.free_vars body in
+      let env' = P.IdMap.filter (fun var _ -> P.IdSet.mem var free) env in
+      eval (C.ValClos (V.Closure (env', xs, body), env)) store k
+    (* S.SetBang (pos, name, next)
+     * Set name to next. *)
+    | C.ExpClos (S.SetBang (p, x, new_val_exp), env), k ->
+      (match try Some (P.IdMap.find x env) with Not_found -> None with
+      | Some loc -> eval (C.ExpClos (new_val_exp, env)) store (K.SetBang (loc, k))
+      | None     -> failwith ("[interp] Unbound identifier: " ^ x
+                              ^ " in identifier lookup at " ^ (P.Pos.string_of_pos p)))
+    | C.ValClos (v, env), K.SetBang (loc, k) ->
+      let store' = V.set_var store loc v in
+      eval (C.ValClos (v, env)) store' k
+    (* S.Object (pos, attrs, props)
+     * Evaluates the attrs, props, then adds the object to the
+     * obj half of the store. *)
+    | C.ExpClos (S.Object (p, attrs, props), env), k ->
+      eval (C.AttrExpClos (attrs, env)) store (K.Object (props, k))
+    | C.AttrValClos (valu, env), K.Object ([], k) -> (* empty props case *)
+      let obj_loc, store = V.add_obj store (valu, P.IdMap.empty) in
+      eval (C.ValClos (V.ObjLoc obj_loc, env)) store k
+    | C.AttrValClos (attrsv, env), K.Object (prop::props, k) ->
+      eval (C.PropExpClos (prop, env)) store (K.Object2 (attrsv, props, [], k))
+    | C.PropValClos (propv, env), K.Object2 (attrsv, prop::props, propvs, k) ->
+      eval (C.PropExpClos (prop, env)) store (K.Object2 (attrsv, props, propv::propvs, k))
+    | C.PropValClos (propv, env), K.Object2 (attrsv, [], propvs, k) ->
+      let add_prop acc (name, propv) = P.IdMap.add name propv acc in
+      let propsv = List.fold_left add_prop P.IdMap.empty (propv::propvs) in
+      let obj_loc, store = V.add_obj store (attrsv, propsv) in
+      eval (C.ValClos (V.ObjLoc obj_loc, env)) store k
+    (* S.Data ({ exp; writable }, enum, config)
+     * Evaluates exp, then continues with the propv to object creation.
+     * S.Accessor ({ getter; setter }, enum, config)
+     * Same as S.Data, but with getter and setter.  *)
+    | C.PropExpClos ((name, prop), env), k ->
+      (match prop with
+      | S.Data ({ S.value = valu; S.writable = writable; }, enum, config) ->
+        eval (C.ExpClos (valu, env)) store (K.DataProp (name, writable, enum, config, k))
+      | S.Accessor ({ S.getter = getter; S.setter = setter; }, enum, config) ->
+        eval (C.ExpClos (getter, env)) store (K.AccProp (name, setter, enum, config, k)))
+    | C.ValClos (valu, env), K.DataProp (name, writable, enum, config, k) ->
+      eval (C.PropValClos ((name, V.Data ({ V.value=valu; V.writable=writable; }, enum, config)), env)) store k
+    | C.ValClos (get_val, env), K.AccProp (name, setter, enum, config, k) ->
+      eval (C.ExpClos (setter, env)) store (K.AccProp2 (name, get_val, enum, config, k))
+    | C.ValClos (set_val, env), K.AccProp2 (name, get_val, enum, config, k) ->
+      eval (C.PropValClos ((name, V.Accessor ({ V.getter=get_val; V.setter=set_val; }, enum, config)), env)) store k
+    (* S.attrs : { primval; code; proto; class; extensible }
+     * Evaluates optional exps primval, code, and proto, then continues
+     * with an S.arrtsv. *)
+    | C.AttrExpClos (attrs, env), k ->
+      let { S.primval = pexp;
+            S.code = cexp;
+            S.proto = proexp;
+            S.klass = kls;
+            S.extensible = ext; } = attrs in
+      let opt_add name ox xs = match ox with Some x -> (name, x)::xs | _ -> xs in
+      let aes = opt_add "prim" pexp (opt_add "code" cexp (opt_add "proto" proexp [])) in
+      (match aes with
+      | [] ->
+        let attrsv = { V.code=None; V.proto=V.Undefined; V.primval=None; V.klass=kls; V.extensible=ext } in
+        eval (C.AttrValClos (attrsv, env)) store k
+      | (name, exp)::pairs -> eval (C.ExpClos (exp, env)) store (K.Attrs (name, pairs, [], kls, ext, k)))
+    | C.ValClos (valu, env), K.Attrs (name, (name', exp)::pairs, valus, kls, ext, k) ->
+      eval (C.ExpClos (exp, env)) store (K.Attrs (name', pairs, (name, valu)::valus, kls, ext, k))
+    | C.ValClos (valu, env), K.Attrs (name, [], valus, kls, ext, k) ->
+      let valus = (name, valu)::valus in
+      let rec opt_get name xs = match xs with
+        | [] -> None
+        | (name', valu)::xs' -> if name = name' then Some valu else opt_get name xs' in
+      let rec und_get name xs = match xs with
+        | [] -> V.Undefined
+        | (name', valu)::xs' -> if name = name' then valu else und_get name xs' in
+      let attrsv = { V.code=(opt_get "code" valus);
+                     V.proto=(und_get "proto" valus);
+                     V.primval=(opt_get "prim" valus);
+                     V.klass=kls;
+                     V.extensible=ext; } in
+      eval (C.AttrValClos (attrsv, env)) store k
+    (* S.GetAttr (pos, pattr, obj, field)
+     * Get the pattr for the obj's field using Ljs_eval's get_attr. *)
+    | C.ExpClos (S.GetAttr (_, attr, obj, field), env), k ->
+      eval (C.ExpClos (obj, env)) store (K.GetAttr (attr, field, k))
+    | C.ValClos (obj_val, env), K.GetAttr (attr, field, k) ->
+      eval (C.ExpClos (field, env)) store (K.GetAttr2 (attr, obj_val, k))
+    | C.ValClos (field_val, env), K.GetAttr2 (attr, obj_val, k) ->
+      eval (C.ValClos (L.get_attr store attr obj_val field_val, env)) store k
+    (* S.SetAttr (pos, pattr, obj, field, next)
+     * The pattr for the obj's field is set to next, using Ljs_eval's
+     * set_attr. *)
+    | C.ExpClos (S.SetAttr (_, pattr, obj, field, next), env), k ->
+      eval (C.ExpClos (obj, env)) store (K.SetAttr (pattr, field, next, k))
+    | C.ValClos (obj_val, env), K.SetAttr (pattr, field, next, k) ->
+      eval (C.ExpClos (field, env)) store (K.SetAttr2 (pattr, next, obj_val, k))
+    | C.ValClos (field_val, env), K.SetAttr2 (pattr, next, obj_val, k) ->
+      eval (C.ExpClos (next, env)) store (K.SetAttr3 (pattr, obj_val, field_val, k))
+    | C.ValClos (valu, env), K.SetAttr3 (pattr, obj_val, field_val, k) ->
+      let b, store = L.set_attr store pattr obj_val field_val valu in
+      eval (C.ValClos (D.bool b, env)) store k
+    (* S.GetObjAttr (pos, oattr, obj)
+     * Get the oattr for obj. *)
+    | C.ExpClos (S.GetObjAttr (_, oattr, obj), env), k ->
+      eval (C.ExpClos (obj, env)) store (K.GetObjAttr (oattr, k))
+    | C.ValClos (obj_val, env), K.GetObjAttr (oattr, k) ->
+      (match obj_val with
+      | V.ObjLoc obj_loc ->
+        let (attrs, _) = V.get_obj store obj_loc in
+        eval (C.ValClos (L.get_obj_attr attrs oattr, env)) store k
+      | _ -> failwith ("[interp] GetObjAttr got a non-object: " ^
+                          (V.pretty_value obj_val)))
+    (* S.SetObjAttr (pos, oattr, obj, next)
+     * The oattr for obj is set to next. *)
+    | C.ExpClos (S.SetObjAttr (_, oattr, obj, next), env), k ->
+      eval (C.ExpClos (obj, env)) store (K.SetObjAttr (oattr, next, k))
+    | C.ValClos (obj_val, env), K.SetObjAttr (oattr, next, k) ->
+      eval (C.ExpClos (next, env)) store (K.SetObjAttr2 (oattr, obj_val, k))
+    | C.ValClos (valu, env), K.SetObjAttr2 (oattr, obj_val, k) ->
+      (match obj_val with
+      | V.ObjLoc loc ->
+        let (attrs, props) = V.get_obj store loc in
+        let attrs' = match oattr, valu with
+          | S.Proto, V.ObjLoc _
+          | S.Proto, V.Null -> { attrs with V.proto=valu }
+          | S.Proto, _ ->
+            failwith ("[interp] Update proto failed: " ^
+                      (V.pretty_value valu))
+          | S.Extensible, V.True  -> { attrs with V.extensible=true }
+          | S.Extensible, V.False -> { attrs with V.extensible=false }
+          | S.Extensible, _ ->
+            failwith ("[interp] Update extensible failed: " ^
+                      (V.pretty_value valu))
+          | S.Code, _ -> failwith "[interp] Can't update Code"
+          | S.Primval, v -> { attrs with V.primval=Some v }
+          | S.Klass, _ -> failwith "[interp] Can't update Klass" in
+        eval (C.ValClos (valu, env)) (V.set_obj store loc (attrs', props)) k
+      | _ -> failwith ("[interp] SetObjAttr got a non-object: " ^
+                       (V.pretty_value obj_val)))
+    (* S.GetField (pos, obj, field, body)
+     * If the getter field in obj is evaluated and, is a data
+     * property, continues with the value; if an accessor, evaluates
+     * the getter with the body and the obj values as arguments. *)
+    | C.ExpClos (S.GetField (p, obj, field, body), env), k ->
+      eval (C.ExpClos (obj, env)) store (K.GetField (p, field, body, env, k))
+    | C.ValClos (obj_val, env), K.GetField (p, field, body, env', k) ->
+      eval (C.ExpClos (field, env)) store (K.GetField2 (p, body, obj_val, env', k))
+    | C.ValClos (field_val, env), K.GetField2 (p, body, obj_val, env', k) ->
+      eval (C.ExpClos (body, env)) store (K.GetField3 (p, obj_val, field_val, env', k))
+    | C.ValClos (body_val, env), K.GetField3 (p, obj_val, field_val, env', k) ->
+      (match (obj_val, field_val) with
+      | (V.ObjLoc _, V.String s) ->
+        let prop = L.get_prop p store obj_val s in
+        (match prop with
+        | Some (V.Data ({V.value=v;}, _, _)) -> eval (C.ValClos (v, env')) store k
+        | Some (V.Accessor ({V.getter=g;},_,_)) ->
+          let (body, env'', store') = (apply p store g [obj_val; body_val]) in
+          eval (C.ExpClos (body, env'')) store' (K.GetField4 (env', k))
+        | None -> eval (C.ValClos (V.Undefined, env')) store k)
+      | _ -> failwith ("[interp] Get field didn't get an object and a string at "
+                       ^ P.Pos.string_of_pos p ^ ". Instead, it got "
+                       ^ V.pretty_value obj_val ^ " and "
+                       ^ V.pretty_value field_val))
+    | C.ValClos (acc_val, _), K.GetField4 (env, k) ->
+      eval (C.ValClos (acc_val, env)) store k
+    (* S.OwnFieldNames (pos, obj)
+     * Create an object in the store with a map of indices to all
+     * obj's properties and the count of that map. *)
+    | C.ExpClos (S.OwnFieldNames (p, obj), env), k ->
+      eval (C.ExpClos (obj, env)) store (K.OwnFieldNames k)
+    | C.ValClos (obj_val, env), K.OwnFieldNames k ->
+      (match obj_val with
+      | V.ObjLoc loc ->
+        let _, props = V.get_obj store loc in
+        let add_name n x m =
+          P.IdMap.add (string_of_int x) (V.Data ({ V.value = V.String n; V.writable = false; },
+                                             false,
+                                             false)) m in
+        let names = P.IdMap.fold (fun k v l -> (k :: l)) props [] in
+        let props = List.fold_right2 add_name names (P.iota (List.length names)) P.IdMap.empty in
+        let d = float_of_int (List.length names) in
+        let final_props =
+          P.IdMap.add "length" (V.Data ({ V.value = V.Num d; V.writable = false; },
+                                    false,
+                                    false)) props in
+        let (new_obj, store) = V.add_obj store (V.d_attrsv, final_props) in
+        eval (C.ValClos (V.ObjLoc new_obj, env)) store k
+      | _ -> failwith ("[interp] OwnFieldNames didn't get an object," ^
+                          " got " ^ (V.pretty_value obj_val) ^ " instead."))
+    (* S.DeleteField(pos, obj, field)
+     * Deletes field from obj. *)
+    | C.ExpClos (S.DeleteField (p, obj, field), env), k ->
+      eval (C.ExpClos (obj, env)) store (K.DeleteField (p, field, k))
+    | C.ValClos (obj_val, env), K.DeleteField (p, field, k) ->
+      eval (C.ExpClos (field, env)) store (K.DeleteField2 (p, obj_val, k))
+    | C.ValClos (field_val, env), K.DeleteField2 (p, obj_val, k) ->
+      (match obj_val, field_val with
+      | V.ObjLoc loc, V.String s ->
+        (match V.get_obj store loc with
+        | attrs, props ->
+          (try match P.IdMap.find s props with
+          | V.Data (_, _, true)
+          | V.Accessor (_, _, true) ->
+            let store' = V.set_obj store loc (attrs, P.IdMap.remove s props) in
+            eval (C.ValClos (V.True, env)) store' k
+          | _ -> eval (C.LobClos (V.Throw ([], V.String "unconfigurable-delete", store))) store k
+           with Not_found -> eval (C.ValClos (V.False, env)) store k))
+      | _ -> failwith ("[interp] Delete field didn't get an object and a string at "
+                       ^ P.Pos.string_of_pos p
+                       ^ ". Instead, it got "
+                       ^ V.pretty_value obj_val
+                       ^ " and "
+                       ^ V.pretty_value field_val))
+    (* S.SetField (pos, obj, field, next, body)
+     * Sets obj's field to next by executing body. *)
+    | C.ExpClos (S.SetField (p, obj, field, next, body), env), k ->
+      eval (C.ExpClos (obj, env)) store (K.SetField  (p, field, next, body, env, k))
+    | C.ValClos (obj_val, env), K.SetField  (p, field, next, body, env', k) ->
+      eval (C.ExpClos (field, env)) store (K.SetField2 (p, next, body, obj_val, env', k))
+    | C.ValClos (field_val, env), K.SetField2 (p, next, body, obj_val, env', k) ->
+      eval (C.ExpClos (next, env)) store (K.SetField3 (p, body, obj_val, field_val, env', k))
+    | C.ValClos (valu, env), K.SetField3 (p, body, obj_val, field_val, env', k) ->
+      eval (C.ExpClos (body, env)) store (K.SetField4 (p, obj_val, field_val, valu, env', k))
+    | C.ValClos (body_val, env), K.SetField4 (p, obj_val, field_val, valu, env', k) ->
+      (match (obj_val, field_val) with
+      | (V.ObjLoc loc, V.String s) ->
+        let ({V.extensible=extensible;} as attrs, props) = V.get_obj store loc in
+        let prop = L.get_prop p store obj_val s in
+        let unwritable = (V.Throw ([], V.String "unwritable-field", store)) in
+        (match prop with
+        | Some (V.Data ({ V.writable = true; }, enum, config)) ->
+          let (enum, config) =
+            if (P.IdMap.mem s props)
+            then (enum, config)  (* 8.12.5, step 3, changing the value of a field *)
+            else (true, true) in (* 8.12.4, last step where inherited.[[writable]] is true *)
+          let store = V.set_obj store loc
+            (attrs,
+             P.IdMap.add s (V.Data ({ V.value = valu; V.writable = true }, enum, config)) props) in
+          eval (C.ValClos (valu, env)) store k
+        | Some (V.Data _) -> eval (C.LobClos unwritable) store k
+        | Some (V.Accessor ({ V.setter = V.Undefined; }, _, _)) ->
+          eval (C.LobClos unwritable) store k
+        | Some (V.Accessor ({ V.setter = setterv; }, _, _)) ->
+          (* 8.12.5, step 5 *)
+          let (body, env'', store') = apply p store setterv [obj_val; body_val] in
+          eval (C.ExpClos (body, env'')) store' (K.SetField5 (env', k))
+        | None ->
+          (* 8.12.5, step 6 *)
+          if extensible
+          then
+            let store = V.set_obj store loc
+              (attrs,
+               P.IdMap.add s (V.Data ({ V.value = valu; V.writable = true; }, true, true)) props) in
+            eval (C.ValClos (valu, env)) store k
+          else
+            eval (C.ValClos (V.Undefined, env)) store k)
+      | _ -> failwith ("[interp] Update field didn't get an object and a string"
+                       ^ P.Pos.string_of_pos p ^ " : " ^ (V.pretty_value obj_val) ^
+                         ", " ^ (V.pretty_value field_val)))
+    | C.ValClos (acc_val, _), K.SetField5 (env, k) ->
+      eval (C.ValClos (acc_val, env)) store k
+    (* S.Op1 (pos, name, arg)
+     * Evaluates a unary operation name on arg. *)
+    | C.ExpClos (S.Op1 (_, name, arg), env), k ->
+      eval (C.ExpClos (arg, env)) store (K.OpOne (name, k))
+    | C.ValClos (arg_val, env), K.OpOne (name, k) ->
+      eval (C.ValClos (D.op1 store name arg_val, env)) store k
+    (* S.Op2 (pos, name, arg1, arg2)
+     * Evaluates a binary operation name on arg1 and arg2. *)
+    | C.ExpClos (S.Op2 (_, name, arg1, arg2), env), k ->
+      eval (C.ExpClos (arg1, env)) store (K.OpTwo (name, arg2, k))
+    | C.ValClos (arg1_val, env), K.OpTwo (name, arg2, k) ->
+      eval (C.ExpClos (arg2, env)) store (K.OpTwo2 (name, arg1_val, k))
+    | C.ValClos (arg2_val, env), K.OpTwo2 (name, arg1_val, k) ->
+      eval (C.ValClos (D.op2 store name arg1_val arg2_val, env)) store k
+    (* S.If (pos, pred, then, else)
+     * Evaluates then if pred, else otherwise. *)
+    | C.ExpClos (S.If (_, pred, than, elze), env), k ->
+      eval (C.ExpClos (pred, env)) store (K.If (env, than, elze, k))
+    | C.ValClos (pred_val, env), K.If (env', than, elze, k) ->
+      if (pred_val = V.True)
+      then eval (C.ExpClos (than, env')) store k
+      else eval (C.ExpClos (elze, env')) store k
+    (* S.App (pos, func, args)
+     * Applies the body of func with the given args. *)
+    | C.ExpClos (S.App (pos, func, args), env), k ->
+      eval (C.ExpClos (func, env)) store (K.App (pos, env, args, k))
+      (* special case for no arg apps *)
+    | C.ValClos (func, env), K.App (pos, env', [], k) ->
+      let (body, env'', store') = apply pos store func [] in
+      eval (C.ExpClos (body, env'')) store' (K.App3 (env', k))
+    | C.ValClos (func, env), K.App  (pos, env', expr::exprs, k) ->
+      eval (C.ExpClos (expr, env')) store (K.App2 (pos, func, env', [] , exprs, k))
+    | C.ValClos (arg_val, env), K.App2 (pos, func, env', vs, expr::exprs, k) ->
+      eval (C.ExpClos (expr, env')) store (K.App2 (pos, func, env', arg_val::vs, exprs, k))
+    | C.ValClos (arg_val,  env), K.App2 (pos, func, env', vs, [], k) ->
+      let (body, env'', store') = apply pos store func (List.rev (arg_val::vs)) in
+      eval (C.ExpClos (body, env'')) store' (K.App3 (env', k))
+    | C.ValClos (body_val, _), K.App3 (env', k) ->
+      eval (C.ValClos (body_val, env')) store k
+    (* S.Seq (pos, left, right)
+     * Evaluates left then right, continuing with right's value. *)
+    | C.ExpClos (S.Seq (_, left, right), env), k ->
+      eval (C.ExpClos (left, env)) store (K.Seq (right, k))
+    | C.ValClos (_, env), K.Seq (right, k) ->
+      eval (C.ExpClos (right, env)) store k
+    (* S.Let (pos, name, expr, body)
+     * Evaluates body with name bound to expr. *)
+    | C.ExpClos (S.Let (_, name, expr, body), env), k ->
+      eval (C.ExpClos (expr, env)) store (K.Let (name, body, k))
+    | C.ValClos (v, env), K.Let (name, body, k) ->
+      let (new_loc, store') = V.add_var store v in
+      eval (C.ExpClos (body, P.IdMap.add name new_loc env)) store' (K.Let2 (env, k))
+    | C.ValClos (v, env), K.Let2 (env', k) ->
+      eval (C.ValClos (v, env')) store k
+    (* S.Rec (pos, name, expr, body)
+     * Evaluates body with name bound to expr, which may contain
+     * recursive references to name. *)
+    | C.ExpClos (S.Rec (_, name, expr, body), env), k ->
+      let (new_loc, store') = V.add_var store V.Undefined in
+      let env' = P.IdMap.add name new_loc env in
+      eval (C.ExpClos (expr, env')) store' (K.Rec (new_loc, body, k))
+    | C.ValClos (v, env), K.Rec (new_loc, body, k) ->
+      eval (C.ExpClos (body, env)) (V.set_var store new_loc v) k
+    (* S.Label (pos, name, expr)
+     * Evaluates expr, catching any Breaks with the matching name. *)
+    | C.ExpClos (S.Label (_, name, exp), env), k ->
+      eval (C.ExpClos (exp, env)) store (K.Label (name, env, k))
+    | C.ValClos (valu, env), K.Label (_, _, k) ->
+      eval (C.ValClos (valu, env)) store k
+    (* S.Break (pos, label, expr)
+     * Breaks to label with expr as the value passed back. *)
+    | C.ExpClos (S.Break (_, label, expr), env), k ->
+      eval (C.ExpClos (expr, env)) store (K.Break (label, k))
+    | C.ValClos (v, _), K.Break (label, k) ->
+      eval (C.LobClos (V.Break ([], label, v, store))) store k
+    | C.LobClos (V.Break (t, label, v, store')), K.Label (name, env, k) ->
+      if name = label then eval (C.ValClos (v, env)) store k
+      else eval (C.LobClos (V.Break (t, label, v, store'))) store k
+    (* S.TryCatch (pos, body, catch)
+     * Evaluates body, evaluating catch with the thrown value as an
+     * argument if a Throw is lobbed up. *)
+    | C.ExpClos (S.TryCatch (p, body, catch), env), k ->
+      eval (C.ExpClos (body, env)) store (K.TryCatch (p, catch, env, k))
+    | C.ValClos (body_val, env'), K.TryCatch (p, catch, env, k) ->
+      eval (C.ValClos (body_val, env')) store k
+    | C.LobClos (V.Throw (_, throw_val, store)), K.TryCatch (p, catch, env, k) ->
+      eval (C.ExpClos (catch, env)) store (K.TryCatch2 (p, throw_val, env, k))
+    | C.ValClos (catch_val, env'), K.TryCatch2 (p, throw_val, env, k) ->
+      let (body, env'', store') = apply p store catch_val [throw_val] in
+      eval (C.ExpClos (body, env'')) store' (K.TryCatch3 (env, k))
+    | C.ValClos (catch_body_val, _), K.TryCatch3 (env, k) ->
+      eval (C.ValClos (catch_body_val, env)) store k
+    (* S.TryFinally (pos, body, fin)
+     * Evaluates body then fin; if an exception is thrown from body
+     * fin will be executed and the exn's store is updated. *)
+    | C.ExpClos (S.TryFinally (_, body, fin), env), k ->
+      eval (C.ExpClos (body, env)) store (K.TryFinally (fin, env, k))
+    | C.ValClos (valu, env'), K.TryFinally (fin, env, k) ->
+      eval (C.ExpClos (fin, env)) store k
+    | C.LobClos except, K.TryFinally (fin, env, k) ->
+      eval (C.ExpClos (fin, env)) store (K.TryFinally2 (except, env, k))
+    | C.ValClos (_, _), K.TryFinally2 (except, env, k) ->
+      (match except with
+      | V.Throw (t, v, _) -> eval (C.LobClos (V.Throw (t, v, store))) store k
+      | V.Break (t, l, v, _) -> eval (C.LobClos (V.Break (t, l, v, store))) store k
+      | _ -> failwith "Try finally caught something other than a throw or break.")
+    (* S.Throw (pos, expr)
+     * Lobs expr up through the future konts. *)
+    | C.ExpClos (S.Throw (_, expr), env), k ->
+      eval (C.ExpClos (expr, env)) store (K.Throw k)
+    | C.ValClos (valu, env), K.Throw k ->
+      eval (C.LobClos (V.Throw ([], valu, store))) store k
+    (* S.Eval (pos, str_expr, bindings)
+     * Evaluates str_expr with the fields defined in the object
+     * bindings added to the environment. *)
+    | C.ExpClos (S.Eval (pos, str, bindings), env), k ->
+      eval (C.ExpClos (str, env)) store (K.Eval (pos, bindings, k))
+    | C.ValClos (str_val, env), K.Eval (pos, bindings, k) ->
+      eval (C.ExpClos (bindings, env)) store (K.Eval2 (pos, str_val, k))
+    | C.ValClos (bind_val, env), K.Eval2 (pos, str_val, k) ->
+      (match str_val, bind_val with
+      | V.String s, V.ObjLoc o ->
+        let expr = desugar s in
+        let env', store' = L.envstore_of_obj pos (V.get_obj store o) store in
+        eval (C.ExpClos (expr, env')) store' (K.Eval3 k)
+      | V.String _, _ -> L.interp_error pos "Non-object given to eval() for env"
+      | v, _ -> eval (C.ValClos (v, env)) store k)
+    | C.ValClos (valu, env), K.Eval3 k ->
+      eval (C.ValClos (valu, env)) store k
+    (* S.Hint (pos, str, expr)
+     * Evaluates expr, continuing with a Snapshot if str is
+     * "___takeS5Snapshot", or just continues with expr's val. *)
+    | C.ExpClos (S.Hint (_, "___takeS5Snapshot", expr), env), k ->
+      eval (C.ExpClos (expr, env)) store (K.Hint k)
+    | C.ExpClos (S.Hint (_, _, expr), env), k ->
+      eval (C.ExpClos (expr, env)) store k
+    | C.ValClos (valu, env), K.Hint k ->
+      eval (C.LobClos (V.Snapshot ([], valu, [], store))) store k
+    (* control cases. TODO: make own exns, remove the store from them. *)
+    | C.LobClos exn, K.Mt -> raise exn
+    | C.LobClos (V.Break (exprs, l, v, s)), k ->
+      eval (C.LobClos (V.Break (C.add_opt clo exprs C.exp_of, l, v, s))) store (K.shed k)
+    | C.LobClos (V.Throw (exprs, v, s)), k ->
+      eval (C.LobClos (V.Throw (C.add_opt clo exprs C.exp_of, v, s))) store (K.shed k)
+    | C.LobClos (V.PrimErr (exprs, v)), k ->
+      eval (C.LobClos (V.PrimErr (add_opt clo exprs C.exp_of, v))) store (K.shed k)
+    | C.LobClos (V.Snapshot (exprs, v, envs, s)), k ->
+      let snap = V.Snapshot (add_opt clo exprs C.exp_of, v, add_opt clo envs C.env_of, s) in
+      eval (C.LobClos snap) store (K.shed k)
+    | _ -> failwith "Encountered an unmatched eval_cesk case."
+  end
+
+(* Ljs_eval's continue_eval and eval_expr, with slight modifications *)
+let continue_eval expr desugar print_trace env store =
+  try
+    Sys.catch_break true;
+    let (v, store) = eval_cesk desugar (C.ExpClos (expr, env)) store K.Mt 0 in
+    L.Answer ([], v, [], store)
+  with
+  | V.Snapshot (exprs, v, envs, store) ->
+    L.Answer (exprs, v, envs, store)
+  | V.Throw (t, v, store) ->
+    let err_msg =
+      match v with
+      | V.ObjLoc loc -> begin match V.get_obj store loc with
+        | _, props -> try match P.IdMap.find "%js-exn" props with
+          | V.Data ({V.value=jserr}, _, _) -> PV.string_of_value jserr store
+          | _ -> PV.string_of_value v store
+          with Not_found -> PV.string_of_value v store
+      end
+      | v -> PV.string_of_value v store in
+    L.err print_trace t (P.sprintf "Uncaught exception: %s\n" err_msg)
+  | V.Break (p, l, v, _) -> failwith ("Broke to top of execution, missed label: " ^ l)
+  | V.PrimErr (t, v) ->
+    L.err print_trace t (P.sprintf "Uncaught error: %s\n" (V.pretty_value v))
+
+let eval_expr expr desugar print_trace =
+  continue_eval expr desugar print_trace P.IdMap.empty (Store.empty, Store.empty)

--- a/src/ljs/ljs_clos.ml
+++ b/src/ljs/ljs_clos.ml
@@ -1,0 +1,42 @@
+module GC = Ljs_gc
+module P = Prelude
+module S = Ljs_syntax
+module V = Ljs_values
+module LocSet = Store.LocSet
+
+(* CESK machine-specific closures *)
+type clos =
+| ExpClos of S.exp * V.env
+| ValClos of V.value * V.env
+| AttrExpClos of S.attrs * V.env
+| AttrValClos of V.attrsv * V.env
+| PropExpClos of (string * S.prop) * V.env
+| PropValClos of (string * V.propv) * V.env
+| LobClos of exn (* bit of a misnomer, since there's no env *)
+
+let exp_of clos = match clos with
+  | ExpClos (expr, _) -> Some expr
+  | _ -> None
+let env_of clos = match clos with
+  | ExpClos (_, env) -> Some env
+  | _ -> None
+let env_of_any clos = match clos with
+  | ExpClos (_, env) -> env
+  | ValClos (_, env) -> env
+  | AttrExpClos  (_, env) -> env
+  | AttrValClos  (_, env) -> env
+  | PropExpClos  (_, env) -> env
+  | PropValClos  (_, env) -> env
+  | LobClos  _ -> P.IdMap.empty
+let add_opt clos xs f = match f clos with
+  | Some x -> x::xs
+  | None -> xs
+
+let locs_of_clos clo = match clo with
+  | ExpClos (_, e) -> GC.locs_of_env e
+  | ValClos (v, e) -> LocSet.union (GC.locs_of_value v) (GC.locs_of_env e)
+  | AttrExpClos (_, e) -> GC.locs_of_env e
+  | AttrValClos (_, e) -> GC.locs_of_env e
+  | PropExpClos (_, e) -> GC.locs_of_env e
+  | PropValClos (_, e) -> GC.locs_of_env e
+  | LobClos _      -> LocSet.empty

--- a/src/ljs/ljs_kont.ml
+++ b/src/ljs/ljs_kont.ml
@@ -1,0 +1,254 @@
+module GC = Ljs_gc
+module P = Prelude
+module S = Ljs_syntax
+module ST = Store
+module V = Ljs_values
+module LocSet = Store.LocSet
+
+type id = string
+
+(* CESK machine-specific continuations *)
+type kont =
+  | Mt
+  | SetBang of ST.loc * kont
+  | GetAttr  of S.pattr * S.exp * kont
+  | GetAttr2 of S.pattr * V.value * kont
+  | SetAttr  of S.pattr * S.exp * S.exp * kont
+  | SetAttr2 of S.pattr * S.exp * V.value * kont
+  | SetAttr3 of S.pattr * V.value * V.value * kont
+  | GetObjAttr of S.oattr * kont
+  | SetObjAttr  of S.oattr * S.exp * kont
+  | SetObjAttr2 of S.oattr * V.value * kont
+  | GetField  of P.Pos.t * S.exp * S.exp * V.env * kont
+  | GetField2 of P.Pos.t * S.exp * V.value * V.env * kont
+  | GetField3 of P.Pos.t * V.value * V.value * V.env * kont
+  | GetField4 of V.env * kont
+  | SetField  of P.Pos.t * S.exp * S.exp * S.exp * V.env * kont
+  | SetField2 of P.Pos.t * S.exp * S.exp * V.value * V.env * kont
+  | SetField3 of P.Pos.t * S.exp * V.value * V.value * V.env * kont
+  | SetField4 of P.Pos.t * V.value * V.value * V.value * V.env * kont
+  | SetField5 of V.env * kont
+  | OwnFieldNames of kont
+  | DeleteField  of P.Pos.t * S.exp * kont
+  | DeleteField2 of P.Pos.t * V.value * kont
+  | OpOne of string * kont
+  | OpTwo  of string * S.exp * kont
+  | OpTwo2 of string * V.value * kont
+  | If of V.env * S.exp * S.exp * kont
+  | App  of P.Pos.t * V.env * S.exp list * kont
+  | App2 of P.Pos.t * V.value * V.env * V.value list * S.exp list * kont
+  | App3 of V.env * kont
+  | Seq of S.exp * kont
+  | Let of id * S.exp * kont
+  | Let2 of V.env * kont
+  | Rec of ST.loc * S.exp * kont
+  | Label of id * V.env * kont
+  | Break of id * kont
+  | TryCatch  of P.Pos.t * S.exp * V.env * kont
+  | TryCatch2 of P.Pos.t * V.value * V.env * kont
+  | TryCatch3 of V.env * kont
+  | TryFinally  of S.exp * V.env * kont
+  | TryFinally2 of exn * V.env * kont
+  | Throw of kont
+  | Eval  of P.Pos.t * S.exp * kont
+  | Eval2 of P.Pos.t * V.value * kont
+  | Eval3 of kont
+  | Hint of kont
+  | Object  of (string * S.prop) list * kont
+  | Object2 of V.attrsv * (string * S.prop) list *
+      (string * V.propv) list * kont
+  | Attrs of string * (string * S.exp) list * (string * V.value) list *
+      string * bool * kont
+  | DataProp of string * bool * bool * bool * kont
+  | AccProp  of string * S.exp * bool * bool * kont
+  | AccProp2 of string * V.value * bool * bool * kont
+
+(* for control flow *)
+let shed k = match k with
+  | SetBang (_, k) -> k
+  | GetAttr (_, _, k) -> k
+  | GetAttr2 (_, _, k) -> k
+  | SetAttr (_, _, _, k) -> k
+  | SetAttr2 (_, _, _, k) -> k
+  | SetAttr3 (_, _, _, k) -> k
+  | GetObjAttr (_, k) -> k
+  | SetObjAttr (_, _, k) -> k
+  | SetObjAttr2 (_, _, k) -> k
+  | GetField (_, _, _, _, k) -> k
+  | GetField2 (_, _, _, _, k) -> k
+  | GetField3 (_, _, _, _, k) -> k
+  | GetField4 (_, k) -> k
+  | SetField (_, _, _, _, _, k) -> k
+  | SetField2 (_, _, _, _, _, k) -> k
+  | SetField3 (_, _, _, _, _, k) -> k
+  | SetField4 (_, _, _, _, _, k) -> k
+  | SetField5 (_, k) -> k
+  | OwnFieldNames k -> k
+  | DeleteField (_, _, k) -> k
+  | DeleteField2 (_, _, k) -> k
+  | OpOne (_, k) -> k
+  | OpTwo (_, _, k) -> k
+  | OpTwo2 (_, _, k) -> k
+  | Mt -> k
+  | If (_, _, _, k) -> k
+  | App (_, _, _, k) -> k
+  | App2 (_, _, _, _, _, k) -> k
+  | App3 (_, k) -> k
+  | Seq (_, k) -> k
+  | Let (_, _, k) -> k
+  | Let2 (_, k) -> k
+  | Rec (_, _, k) -> k
+  | Break (_, k) -> k
+  | TryCatch (_, _, _, k) -> k
+  | TryCatch2 (_, _, _, k) -> k
+  | TryCatch3 (_, k) -> k
+  | TryFinally (_, _, k) -> k
+  | TryFinally2 (_, _, k) -> k
+  | Throw k -> k
+  | Eval (_, _, k) -> k
+  | Eval2 (_, _, k) -> k
+  | Eval3 k -> k
+  | Hint k -> k
+  | Object (_, k) -> k
+  | Object2 (_, _, _, k) -> k
+  | Attrs (_, _, _, _, _, k) -> k
+  | DataProp (_, _, _, _, k) -> k
+  | AccProp (_, _, _, _, k) -> k
+  | AccProp2 (_, _, _, _, k) -> k
+  | Label (_, _, k) -> k
+
+let string_of_kont k = match k with
+  | SetBang (_, _) -> "k.setbang"
+  | GetAttr (_, _, _) -> "k.getattr"
+  | GetAttr2 (_, _, _) -> "k.getattr2"
+  | SetAttr (_, _, _, _) -> "k.setattr"
+  | SetAttr2 (_, _, _, _) -> "k.setattr2"
+  | SetAttr3 (_, _, _, _) -> "k.setattr3"
+  | GetObjAttr (_, _) -> "k.getobjattr"
+  | SetObjAttr (_, _, _) -> "k.setobjattr"
+  | SetObjAttr2 (_, _, _) -> "k.setobjattr2"
+  | GetField (_, _, _, _, _) -> "k.getfield"
+  | GetField2 (_, _, _, _, _) -> "k.getfield2"
+  | GetField3 (_, _, _, _, _) -> "k.getfield3"
+  | GetField4 (_, _) -> "k.getfield4"
+  | SetField (_, _, _, _, _, _) -> "k.setfield"
+  | SetField2 (_, _, _, _, _, _) -> "k.setfield2"
+  | SetField3 (_, _, _, _, _, _) -> "k.setfield3"
+  | SetField4 (_, _, _, _, _, _) -> "k.setfield4"
+  | SetField5 (_, _) -> "k.setfield5"
+  | OwnFieldNames _ -> "k.ownfieldnames"
+  | DeleteField (_, _, _) -> "k.deletefield"
+  | DeleteField2 (_, _, _) -> "k.deletefield2"
+  | OpOne (_, _) -> "k.opone"
+  | OpTwo (_, _, _) -> "k.optwo"
+  | OpTwo2 (_, _, _) -> "k.optwo2"
+  | Mt -> "k.mt"
+  | If (_, _, _, _) -> "k.if"
+  | App (_, _, _, _) -> "k.app"
+  | App2 (_, _, _, _, _, _) -> "k.app2"
+  | App3 (_, _) -> "k.app3"
+  | Seq (_, _) -> "k.seq"
+  | Let (_, _, _) -> "k.let"
+  | Let2 (_, _) -> "k.let2"
+  | Rec (_, _, _) -> "k.rec"
+  | Break (label, _) -> "k.break: "^label
+  | TryCatch (_, _, _, _) -> "k.trycatch"
+  | TryCatch2 (_, _, _, _) -> "k.trycatch2"
+  | TryCatch3 (_, _) -> "k.trycatch3"
+  | TryFinally (_, _, _) -> "k.tryfinally"
+  | TryFinally2 (_, _, _) -> "k.tryfinally2"
+  | Throw _ -> "k.throw"
+  | Eval (_, _, _) -> "k.eval"
+  | Eval2 (_, _, _) -> "k.eval2"
+  | Eval3 _ -> "k.eval3"
+  | Hint _ -> "k.hint"
+  | Object (_, _) -> "k.object"
+  | Object2 (_, _, _, _) -> "k.object2"
+  | Attrs (_, _, _, _, _, _) -> "k.attrs"
+  | DataProp (_, _, _, _, _) -> "k.dataprop"
+  | AccProp (_, _, _, _, _) -> "k.accprop"
+  | AccProp2 (_, _, _, _, _) -> "k.accprop2"
+  | Label (_, _, _) -> "k.label"
+
+
+let locs_of_values vs a =
+  List.fold_left (fun a n -> (GC.locs_of_value n)::a) a vs
+
+let locs_of_opt ox locs_of_x = match ox with
+  | Some v -> locs_of_x v
+  | None -> ST.LocSet.empty
+
+let locs_of_opt_val ov = locs_of_opt ov GC.locs_of_value
+
+let locs_of_propv pv = match pv with
+  | V.Data ({ V.value=v }, _, _) -> GC.locs_of_value v
+  | V.Accessor ({ V.getter=gv; V.setter=sv }, _, _) ->
+    LocSet.union (GC.locs_of_value gv) (GC.locs_of_value sv)
+
+let locs_of_propvs pvs a = List.fold_left (fun a (_, n) -> (locs_of_propv n)::a) a pvs
+
+let locs_of_attrsv av =
+  let { V.code=ov; V.proto=v; V.primval=ov' } = av in
+  LocSet.unions [locs_of_opt_val ov; GC.locs_of_value v; locs_of_opt_val ov']
+
+let rec locs_of_kont ko : LocSet.t = match ko with
+  | SetBang (l, k) -> LocSet.union (LocSet.singleton l) (locs_of_kont k)
+  | GetAttr (_, _, k) -> locs_of_kont k
+  | GetAttr2 (_, v, k) -> LocSet.union (GC.locs_of_value v) (locs_of_kont k)
+  | SetAttr (_, _, _, k) -> locs_of_kont k
+  | SetAttr2 (_, _, v, k) -> LocSet.union (GC.locs_of_value v) (locs_of_kont k)
+  | SetAttr3 (_, v1, v2, k) ->
+    LocSet.unions [GC.locs_of_value v1; GC.locs_of_value v2; locs_of_kont k]
+  | GetObjAttr (_, k) -> locs_of_kont k
+  | SetObjAttr (_, _, k) -> locs_of_kont k
+  | SetObjAttr2 (_, v, k) -> LocSet.union (GC.locs_of_value v) (locs_of_kont k)
+  | GetField (_, _, _, e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | GetField2 (_, _, v, e, k) -> LocSet.unions [GC.locs_of_value v; GC.locs_of_env e; locs_of_kont k]
+  | GetField3 (_, v1, v2, e, k) ->
+    LocSet.unions [GC.locs_of_value v1; GC.locs_of_value v2; GC.locs_of_env e; locs_of_kont k]
+  | GetField4 (e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | SetField (_, _, _, _, e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | SetField2 (_, _, _, v, e, k) ->
+    LocSet.unions [GC.locs_of_value v; GC.locs_of_env e; locs_of_kont k]
+  | SetField3 (_, _, v1, v2, e, k) ->
+    LocSet.unions [GC.locs_of_value v1; GC.locs_of_value v2; GC.locs_of_env e; locs_of_kont k]
+  | SetField4 (_, v1, v2, v3, e, k) ->
+    LocSet.unions [GC.locs_of_value v1; GC.locs_of_value v2; GC.locs_of_value v3; GC.locs_of_env e;
+                   locs_of_kont k]
+  | SetField5 (e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | OwnFieldNames k -> locs_of_kont k
+  | DeleteField (_, _, k) -> locs_of_kont k
+  | DeleteField2 (_, v, k) -> LocSet.union (GC.locs_of_value v) (locs_of_kont k);
+  | OpOne (_, k) -> locs_of_kont k
+  | OpTwo (_, _, k) -> locs_of_kont k
+  | OpTwo2 (_, v, k) -> LocSet.union (GC.locs_of_value v) (locs_of_kont k)
+  | If (e, _, _, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | App (_, e, _, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | App2 (_, v, e, vs, _, k) ->
+    LocSet.unions (locs_of_values vs [GC.locs_of_value v; GC.locs_of_env e; locs_of_kont k])
+  | App3 (e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | Seq (_, k) -> locs_of_kont k
+  | Let (_, _, k) -> locs_of_kont k
+  | Let2 (_, k) -> locs_of_kont k
+  | Rec (l, _, k) -> LocSet.add l (locs_of_kont k)
+  | Break (_, k) -> locs_of_kont k
+  | TryCatch (_, _, e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | TryCatch2 (_, v, e, k) -> LocSet.unions [GC.locs_of_value v; GC.locs_of_env e; locs_of_kont k]
+  | TryCatch3 (e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | TryFinally (_, e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | TryFinally2 (_, e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | Throw k -> locs_of_kont k
+  | Eval (_, _, k) -> locs_of_kont k
+  | Eval2 (_, _, k) -> locs_of_kont k
+  | Eval3 k -> locs_of_kont k
+  | Hint k -> locs_of_kont k
+  | Object (_, k) -> locs_of_kont k
+  | Object2 (attrsv, _, propvs, k) ->
+    LocSet.unions (locs_of_propvs propvs [locs_of_attrsv attrsv; locs_of_kont k])
+  | Attrs (_, _, nvs, _, _, k) ->
+    LocSet.unions (List.fold_left (fun a (_, n) -> (GC.locs_of_value n)::a) [locs_of_kont k] nvs)
+  | DataProp (_, _, _, _, k) -> locs_of_kont k
+  | AccProp (_, _, _, _, k) -> locs_of_kont k
+  | AccProp2 (_, v, _, _, k) -> LocSet.union (GC.locs_of_value v) (locs_of_kont k)
+  | Label (_, e, k) -> LocSet.union (GC.locs_of_env e) (locs_of_kont k)
+  | Mt -> LocSet.empty

--- a/src/s5.ml
+++ b/src/s5.ml
@@ -2,6 +2,7 @@ open List
 open Prelude
 open Ljs
 open Ljs_eval
+open Ljs_cesk
 open Ljs_syntax
 open Ljs_pretty_html
 open Reachability
@@ -323,9 +324,21 @@ module S5 = struct
              FX.horz [FX.text "ERROR  <="; Ljs_cps_absdelta.ValueLattice.pretty err]] Format.str_formatter;
     printf "%s\n" (Format.flush_str_formatter ())
 
+  let ljs_cesk cmd () =
+    let ljs = pop_ljs cmd in
+    let answer = Ljs_cesk.eval_expr ljs (desugar !json_path) !stack_trace in
+    push_answer answer
+
   let ljs_eval cmd () =
     let ljs = pop_ljs cmd in
     let answer = Ljs_eval.eval_expr ljs (desugar !json_path) !stack_trace in
+    push_answer answer
+
+  let continue_cesk_eval cmd () =
+    let ljs = pop_ljs cmd in
+    let Ljs_eval.Answer (_, _, envs, store) = pop_answer cmd in
+    let answer = Ljs_cesk.continue_eval
+      ljs (desugar !json_path) !stack_trace (last envs) store in
     push_answer answer
 
   let continue_ljs_eval cmd () =
@@ -436,6 +449,11 @@ module S5 = struct
           (showType [AnswerT; LjsT] [AnswerT]);
         unitCmd "-eval-s5" ljs_eval
           "evaluate S5 code";
+        unitCmd "-continue-cesk-eval"
+          (fun cmd () -> continue_cesk_eval cmd (); print_value cmd ())
+          (showType [AnswerT; LjsT] [AnswerT]);
+        unitCmd "-eval-cesk" ljs_cesk
+          "evaluate S5 code using a CESK";
         unitCmd "-eval-cps" cps_eval
           "evaluate code in CPS form";
         unitCmd "-eval-cps-abs" cps_eval_abs

--- a/tests/single_test.sh
+++ b/tests/single_test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ ! -f 'init.heap' ]; then
+  echo "Rebuilding heap snapshots..."
+  source save_snapshots.sh &> /dev/null
+fi
+
+if [ $# -gt 1 ]; then
+  TYPE=$1
+  if [ $TYPE == 's5' -o $TYPE == 'cesk' ]; then
+      VERB=''
+      if [ "$#" -gt 2 -a "$3" == "-v" ]; then
+        VERB='t'
+        echo 'Running test file: '$2
+      fi
+      COMM='../obj/s5.d.byte -load init.heap -desugar '$2' -continue-'$TYPE'-eval'
+      STR1=`$COMM`
+      TEST=`echo $STR1 | grep "passed\|Passed"`
+      if [ -n "$TEST" ]; then
+        echo 'Passed'
+      else
+        echo 'Failed'
+      fi
+      if [ $VERB ]; then
+        echo 'Test output:'
+        echo $STR1
+      fi
+      exit 0
+  fi
+fi
+echo "Usage: single_test.sh {s5, cesk} some/file/path.js (-v)"
+exit 1


### PR DESCRIPTION
Added:
  src/ljs/ljs_cesk.ml
- main CESK evaluate function and entry point from s5.ml
  src/ljs/ljs_clos.ml
- machine-specific closures and functions on closures
  src/ljs/ljs_kont.ml
- machine-specific continuations and functions on continuations
  tests/single_test.sh
- easily run single tests for with CESK or S5 eval

Modified:
  src/s5.ml
- added -eval-cesk and -continue-cesk-eval evaluation flags

Currently passing 208 tests while failing 4--parity with ljs_eval.

Future work:
- improve our naive garbage collection strategy
- develop this evaluator into an analyzer using the "abstracting
  abstract machines" approach (Van Horn and Might, CACM'11)
