### PR TITLE
Fix test case tests/unit-tests/regexp-exec.js

### DIFF
--- a/tests/unit-tests/regexp-exec.js
+++ b/tests/unit-tests/regexp-exec.js
@@ -9,9 +9,9 @@ var l = [];
   l.push(a[0]);
   foo();
 })();
-if (l[0] === "foo" &&
+if (l[0] === "baz" &&
     l[1] === "bar" &&
-    l[2] === "baz") {
+    l[2] === "foo") {
   console.log("passed");
 }
 


### PR DESCRIPTION
The test case is failing both with LambdaS5 and SpiderMonkey because Array.push pushes items to the end and not to the beginning of the array.

This fix makes it pass for both.
