### PR TITLE
Implement Date.Prototype.{getHours,getMinutes,getSeconds}.

### DIFF
--- a/envs/es5.env
+++ b/envs/es5.env
@@ -3604,10 +3604,13 @@ let [%IsFinite] = func(n) {
   prim("!", (n !== n || n === +inf || n === -inf))
 }
 
-// http://es5.github.com/#x15.9.1.2
+// http://es5.github.com/#x15.9.1.2 and http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.10
+let [%HoursPerDay] = 24
+let [%MinutesPerHour] = 60
+let [%SecondsPerMinute] = 60
 let [%msPerDay] = 86400000
 let [%msPerHour] = 3600000
-let [%msPerMin] = 60000
+let [%msPerMinute] = 60000
 let [%msPerSecond] = 1000
 let [%Day] = func(t) { prim("floor", prim("/", t, %msPerDay)) }
 let [%TimeWithinDay] = func(t) { prim("%", t, %msPerDay) }
@@ -3741,6 +3744,21 @@ let [%DateFromTime] = func(t) {
   else { %TypeError("Something terrible happened in %DateFromTime")}
 }
 
+// http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.10
+let [%HourFromTime] = func(t) {
+  prim("%", prim("floor", prim("/", t, %msPerHour)), %HoursPerDay)
+}
+
+// http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.10
+let [%MinFromTime] = func(t) {
+  prim("%", prim("floor", prim("/", t, %msPerMinute)), %MinutesPerHour)
+}
+
+// http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.10
+let [%SecFromTime] = func(t) {
+  prim("%", prim("floor", prim("/", t, %msPerSecond)), %SecondsPerMinute)
+}
+
 let [%LocalTime] = func(t) { t }
 
 let [%MakeDate] = func(day, time) { prim("+", prim("*", day, %msPerDay), time) }
@@ -3792,7 +3810,7 @@ let [%MakeTime] = func(h, m, s, ms) {
       prim("+",
         prim("+",
           prim("*", hour, %msPerHour),
-          prim("*", min, %msPerMin)),
+          prim("*", min, %msPerMinute)),
         prim("*", sec, %msPerSecond)),
       millis)) {
       t
@@ -3933,6 +3951,33 @@ let [%dategetDate] = {[#code: %dategetDateLambda, #proto : %FunctionProto,]}
 
 {%define15Property(%DateProto, "getDate", %dategetDate)}
 
+let [%dategetHoursLambda] = func(this, args) {
+  let (t = this[<#primval>])
+  if (t === NaN) { t } else { %HourFromTime(%LocalTime(t)) }
+}
+
+let [%dategetHours] = {[#code: %dategetHoursLambda, #proto : %FunctionProto,]}
+
+{%define15Property(%DateProto, "getHours", %dategetHours)}
+
+let [%dategetMinutesLambda] = func(this, args) {
+  let (t = this[<#primval>])
+  if (t === NaN) { t } else { %MinFromTime(%LocalTime(t)) }
+}
+
+let [%dategetMinutes] = {[#code: %dategetMinutesLambda, #proto : %FunctionProto,]}
+
+{%define15Property(%DateProto, "getMinutes", %dategetMinutes)}
+
+let [%dategetSecondsLambda] = func(this, args) {
+  let (t = this[<#primval>])
+  if (t === NaN) { t } else { %SecFromTime(%LocalTime(t)) }
+}
+
+let [%dategetSeconds] = {[#code: %dategetSecondsLambda, #proto : %FunctionProto,]}
+
+{%define15Property(%DateProto, "getSeconds", %dategetSeconds)}
+
 let [%defineNYIProperty] = func(base, name) {
   let (unimplFunc = func(this, args) {
     %TypeError(prim("string+", name, " NYI"))
@@ -3951,11 +3996,11 @@ let [%defineNYIProperty] = func(base, name) {
 //  %defineNYIProperty(%DateProto, "getDate");
   %defineNYIProperty(%DateProto, "getUTCDate");
   %defineNYIProperty(%DateProto, "getUTCDay");
-  %defineNYIProperty(%DateProto, "getHours");
+//  %defineNYIProperty(%DateProto, "getHours");
   %defineNYIProperty(%DateProto, "getUTCHours");
-  %defineNYIProperty(%DateProto, "getMinutes");
+//  %defineNYIProperty(%DateProto, "getMinutes");
   %defineNYIProperty(%DateProto, "getUTCMinutes");
-  %defineNYIProperty(%DateProto, "getSeconds");
+//  %defineNYIProperty(%DateProto, "getSeconds");
   %defineNYIProperty(%DateProto, "getUTCSeconds");
   %defineNYIProperty(%DateProto, "getMilliseconds");
   %defineNYIProperty(%DateProto, "getUTCMilliseconds");


### PR DESCRIPTION
Many tests (at least in the first ones of test262) were failing just because `Date.Prototype.getHours` and `Date.Prototype.getMinutes` were not implemented, so I implemented them.
I also implemented `getSeconds`.

I hope my implementation is ok. I tried to follow the standard and what you already implemented, but you probably should double-check this work.
