### PR TITLE
Fix wrong number of arguments passed by Function.prototype.apply.

### DIFF
--- a/envs/es5.env
+++ b/envs/es5.env
@@ -953,6 +953,16 @@ let [%applylambda] = func(this, args) {
     } else { undefined };
     %ObjectTypeCheck(applyArgs);
     applyArgs := %mkArgsObj(applyArgs);
+    // %mkArgsObj adds a "%new" property, which increases the length.
+    if (prim("typeof", args["1"]) !== 'undefined' && prim("hasOwnProperty", args["1"], "length")) {
+      %defineOwnProperty(applyArgs, "length", {
+        []
+        "value": {#value args["1"]["length"], #writable false},
+            "writable" : {#value true, #writable false},
+            "configurable": {#value true, #writable false},
+            "enumerable": {#value false, #writable false}
+          })
+    };
     this(args["0"], applyArgs)
   }
 }


### PR DESCRIPTION
`%applylambda` makes a call to `%mkArgsObj`, which adds a property (`%new`), which increases the length of the array passed to the called function.
This patch restores the original length, if any.

It also makes test unit-tests/apply-args.js pass.
