### PR TITLE
Fix error format in Ljs_eval.get_prop.

### DIFF
--- a/src/ljs/ljs_eval.ml
+++ b/src/ljs/ljs_eval.ml
@@ -35,10 +35,10 @@ let rec get_prop p store obj field =
          try Some (IdMap.find field props)
          with Not_found -> get_prop p store pvalue field
       end
-    | _ -> failwith (interp_error p 
+    | _ -> failwith (interp_error p (
            "get_prop on a non-object.  The expression was (get-prop " 
          ^ pretty_value obj 
-         ^ " " ^ field ^ ")")
+         ^ " " ^ field ^ ")"))
 
 let get_obj_attr attrs attr = match attrs, attr with
   | { proto=proto }, S.Proto -> proto


### PR DESCRIPTION
There was a parenthesing issue in the `failwith` message oin `get_prop`.

Before the patch:

```
vlorentz@gommier:~/js/LambdaS5/tests(master)$ echo "{[#proto: 'Object']}['__proto__']" | ../obj/s5.d.byte -load init.heap /dev/stdin -continue-s5-eval

Uncaught error: "[interp] (/dev/stdin:1:0-33) get_prop on a non-object.  The expression was (get-prop "

Fatal error: exception Failure("Runtime error")
```

After the patch:

```
vlorentz@gommier:~/js/LambdaS5/tests(master)$ echo "{[#proto: 'Object']}['__proto__']" | ../obj/s5.d.byte -load init.heap /dev/stdin -continue-s5-eval

Uncaught error: "[interp] (/dev/stdin:1:0-33) get_prop on a non-object.  The expression was (get-prop "Object" __proto__)"

Fatal error: exception Failure("Runtime error")
```
